### PR TITLE
Core: 사용자 정보를 위한 Resolver, Filter 구현 

### DIFF
--- a/src/main/java/com/friday/commerce/core/security/annotation/CurrentUser.java
+++ b/src/main/java/com/friday/commerce/core/security/annotation/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.friday.commerce.core.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/friday/commerce/core/security/aspect/AuthorizationAspect.java
+++ b/src/main/java/com/friday/commerce/core/security/aspect/AuthorizationAspect.java
@@ -1,5 +1,7 @@
 package com.friday.commerce.core.security.aspect;
 
+import static com.friday.commerce.core.utils.AuthKeys.Attr.USER_ROLE;
+
 import com.friday.commerce.core.security.annotation.RequireRole;
 import com.friday.commerce.core.security.model.UserRole;
 import com.friday.commerce.core.web.exception.AppErrorCode;
@@ -22,7 +24,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @Component
 public class AuthorizationAspect {
 
-    private final static String ATTR_USER_ROLE = "X-User-Role";
 
     @Before("@within(com.friday.commerce.core.security.annotation.RequireRole) || @annotation(com.friday.commerce.core.security.annotation.RequireRole)")
     public void requireRole(JoinPoint jp) {
@@ -72,7 +73,7 @@ public class AuthorizationAspect {
         }
 
         HttpServletRequest request = attrs.getRequest();
-        Object roleAttr = request.getAttribute(ATTR_USER_ROLE);
+        Object roleAttr = request.getAttribute(USER_ROLE);
 
         if (roleAttr == null) {
             throw new AppException(AppErrorCode.MISSING_HEADER_USER_ROLE);

--- a/src/main/java/com/friday/commerce/core/security/jwt/JwtProvider.java
+++ b/src/main/java/com/friday/commerce/core/security/jwt/JwtProvider.java
@@ -109,7 +109,11 @@ public class JwtProvider {
 
     public String getAtUserRole(String at) {
         Claims c = parseAtClaims(at);
-        return c.get(CLAIM_USER_ROLE).toString();
+        String role = c.get(CLAIM_USER_ROLE, String.class);
+        if (role == null || role.isBlank()) {
+            throw new TokenException(JwtErrorCode.INVALID_CLAIMS);
+        }
+        return role;
     }
 
 

--- a/src/main/java/com/friday/commerce/core/security/jwt/JwtProvider.java
+++ b/src/main/java/com/friday/commerce/core/security/jwt/JwtProvider.java
@@ -83,10 +83,10 @@ public class JwtProvider {
     }
 
     public String getAtJti(String token) {
-        Claims claims = parseRtClaims(token);
+        Claims claims = parseAtClaims(token);
         return claims.getId();
     }
-    
+
     public long getRtTtlMs(String rt) {
         Claims c = parseRtClaims(rt);
         return Math.max(c.getExpiration().getTime() - System.currentTimeMillis(), 0);
@@ -107,9 +107,10 @@ public class JwtProvider {
         return Long.parseLong(c.getSubject());
     }
 
-
-
-
+    public String getAtUserRole(String at) {
+        Claims c = parseAtClaims(at);
+        return c.get(CLAIM_USER_ROLE).toString();
+    }
 
 
     private Claims parseRtClaims(String rt) {

--- a/src/main/java/com/friday/commerce/core/security/model/CurrentUserInfo.java
+++ b/src/main/java/com/friday/commerce/core/security/model/CurrentUserInfo.java
@@ -1,0 +1,12 @@
+package com.friday.commerce.core.security.model;
+
+public record CurrentUserInfo(
+        Long userId,
+        UserRole userRole
+) {
+
+    public static CurrentUserInfo of(Long userId, UserRole userRole) {
+        return new CurrentUserInfo(userId, userRole);
+    }
+
+}

--- a/src/main/java/com/friday/commerce/core/utils/AuthKeys.java
+++ b/src/main/java/com/friday/commerce/core/utils/AuthKeys.java
@@ -1,0 +1,18 @@
+package com.friday.commerce.core.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AuthKeys {
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static final class Header {
+        public static final String HDR_USER_ID = "X-User-Id";
+        public static final String HDR_USER_ROLE = "X-User-Role";
+    }
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    public static final class Attr {
+        public static final String USER_ID = "auth.userId";
+        public static final String USER_ROLE = "auth.userRole";
+    }
+}

--- a/src/main/java/com/friday/commerce/core/web/config/WebConfig.java
+++ b/src/main/java/com/friday/commerce/core/web/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.friday.commerce.core.web.config;
+
+import com.friday.commerce.core.web.resolver.CurrentUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/friday/commerce/core/web/exception/AppErrorCode.java
+++ b/src/main/java/com/friday/commerce/core/web/exception/AppErrorCode.java
@@ -20,6 +20,7 @@ public enum AppErrorCode implements ErrorCode {
 
     // 요청/형식/프로토콜
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "공통: 잘못된 입력입니다."),
+    INVALID_USER_INFO(HttpStatus.BAD_REQUEST, "공통: 현재 사용자 정보가 올바르지 않습니다."),
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "공통: 입력값 검증에 실패했습니다."),
     BINDING_ERROR(HttpStatus.BAD_REQUEST, "공통: 요청 데이터 바인딩에 실패했습니다."),
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "공통: 파라미터 타입이 일치하지 않습니다."),
@@ -37,7 +38,10 @@ public enum AppErrorCode implements ErrorCode {
     // [헤더/메타데이터]
     INVALID_HEADER(HttpStatus.BAD_REQUEST, "공통: 잘못된 헤더 정보입니다."),
     MISSING_HEADER(HttpStatus.BAD_REQUEST, "공통: 필수 헤더가 누락되었습니다."),
+    MISSING_HEADER_USER_ID(HttpStatus.BAD_REQUEST, "공통: 회원 ID 헤더가 누락되었습니다."),
     MISSING_HEADER_USER_ROLE(HttpStatus.BAD_REQUEST, "공통: 회원 권한 헤더가 누락되었습니다."),
+    INVALID_HEADER_USER_ID(HttpStatus.BAD_REQUEST, "공통: 회원 ID 헤더가 잘못된 값 입니다."),
+    INVALID_HEADER_USER_ID_NOT_INTEGER(HttpStatus.BAD_REQUEST, "공통: 회원 ID 헤더 값이 숫자가 아닙니다."),
     INVALID_HEADER_USER_ROLE(HttpStatus.BAD_REQUEST, "공통: 값이 올바른 회원 권한 형식이 아닙니다."),
     INVALID_QUERY_PARAMETER(HttpStatus.BAD_REQUEST, "공통: 잘못된 쿼리 파라미터입니다."),
 

--- a/src/main/java/com/friday/commerce/core/web/filter/ExceptionHandlingFilter.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/ExceptionHandlingFilter.java
@@ -1,0 +1,126 @@
+package com.friday.commerce.core.web.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.friday.commerce.core.web.exception.AppException;
+import com.friday.commerce.core.web.exception.AppErrorCode;
+import com.friday.commerce.core.web.exception.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j(topic = "ExceptionHandlingFilter")
+@RequiredArgsConstructor
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilterErrorDispatch() {
+        return true; // ERROR 디스패치 중복 방지
+    }
+
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true; // (선택) 비동기 디스패치 중복 방지
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (AppException ex) {
+            writeAppError(response, request, ex);
+        } catch (Throwable t) { // 마지막 방어막
+            log.error("Unhandled throwable", t);
+            writeGenericError(response, request);
+        }
+    }
+
+    private void writeAppError(HttpServletResponse resp, HttpServletRequest req, AppException ex)
+            throws IOException {
+        if (resp.isCommitted()) return;
+
+        ErrorCode code = ex.getErrorCode();
+        HttpStatus status = (code != null && code.getStatus() != null)
+                ? code.getStatus()
+                : HttpStatus.BAD_REQUEST;
+
+        String message = (code != null && StringUtils.hasText(code.getMessage()))
+                ? code.getMessage()
+                : (StringUtils.hasText(ex.getMessage()) ? ex.getMessage() : status.getReasonPhrase());
+
+        logAtProperLevel(code, ex);
+
+        String codeName = (code instanceof Enum<?> e) ? e.name()
+                : (code != null ? code.getClass().getSimpleName() : "APP_ERROR");
+
+        resp.resetBuffer();
+        resp.setStatus(status.value());
+        resp.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now().toString(),
+                "status", status.value(),
+                "error", status.getReasonPhrase(),
+                "code", codeName,
+                "message", message,
+                "path", req.getRequestURI()
+        );
+        objectMapper.writeValue(resp.getWriter(), body);
+        resp.flushBuffer();
+    }
+
+    private void writeGenericError(HttpServletResponse resp, HttpServletRequest req)
+            throws IOException {
+        if (resp.isCommitted()) return;
+
+        HttpStatus status = AppErrorCode.INTERNAL_SERVER_ERROR.getStatus();
+        String message = AppErrorCode.INTERNAL_SERVER_ERROR.getMessage();
+
+        resp.resetBuffer();
+        resp.setStatus(status.value());
+        resp.setContentType("application/json;charset=UTF-8");
+
+        Map<String, Object> body = Map.of(
+                "timestamp", OffsetDateTime.now().toString(),
+                "status", status.value(),
+                "error", status.getReasonPhrase(),
+                "code", AppErrorCode.INTERNAL_SERVER_ERROR.name(),
+                "message", message,
+                "path", req.getRequestURI()
+        );
+        resp.getWriter().write(new ObjectMapper().writeValueAsString(body));
+        resp.flushBuffer();
+    }
+
+    private void logAtProperLevel(ErrorCode code, AppException ex) {
+        HttpStatus status = (code != null) ? code.getStatus() : null;
+        if (status == null) {
+            log.error("AppException without status", ex);
+            return;
+        }
+        if (status.is4xxClientError()) {
+            log.warn("Handled AppException: {} ({})", codeName(code), status, ex);
+        } else {
+            log.error("Handled AppException: {} ({})", codeName(code), status, ex);
+        }
+    }
+
+    private String codeName(ErrorCode code) {
+        return (code instanceof Enum<?> e) ? e.name()
+                : (code != null ? code.getClass().getSimpleName() : "APP_ERROR");
+    }
+}

--- a/src/main/java/com/friday/commerce/core/web/filter/FilterConfig.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/FilterConfig.java
@@ -1,0 +1,78 @@
+package com.friday.commerce.core.web.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.friday.commerce.core.security.jwt.JwtProvider;
+import jakarta.servlet.DispatcherType;
+import java.util.EnumSet;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+
+/**
+ * 필터 체인 구성
+ *
+ * <p> [순서]
+ * 1) ExceptionHandlingFilter  (최상단)  : 필터/서블릿 레이어에서 던진 AppException을 JSON 표준 응답으로 변환
+ * 2) JwtAuthenticationFilter  (그 다음) : 경로 정책(EXCLUDE/OPTIONAL/REQUIRED)에 따라 JWT 검증 및 사용자 속성 세팅
+ *
+ * <p> 주의:
+ * - Spring MVC의 @ControllerAdvice는 DispatcherServlet 내부에서만 동작한다.
+ *   필터 단계에서 던진 예외는 여기서 먼저 처리되어야 JSON 표준 응답을 보장할 수 있다.
+ * - ERROR 디스패치는 ExceptionHandlingFilter 내부에서 shouldNotFilterErrorDispatch() = true로 막는다.
+ *   따라서 DispatcherType.ERROR는 등록하지 않는다.
+ */
+@Configuration
+public class FilterConfig {
+
+    // 순서는 "숫자가 낮을수록 먼저 실행"
+    private static final int ORDER_EXCEPTION = Ordered.HIGHEST_PRECEDENCE;        // 맨 앞
+    private static final int ORDER_JWT       = Ordered.HIGHEST_PRECEDENCE + 10;   // 예외 필터 다음
+
+    /**
+     * 전역 예외 처리 필터 (디스패처 이전)
+     * - 하위 필터/서블릿에서 던진 AppException을 받아 JSON 표준 응답으로 변환
+     * - ERROR 디스패치 중복 방지는 필터 내부에서 처리(shouldNotFilterErrorDispatch=true)
+     */
+    @Bean
+    public FilterRegistrationBean<ExceptionHandlingFilter> exceptionHandlingFilter(ObjectMapper om) {
+        FilterRegistrationBean<ExceptionHandlingFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(new ExceptionHandlingFilter(om));
+        reg.setName("exceptionHandlingFilter");
+        reg.addUrlPatterns("/*"); // 모든 요청
+        reg.setDispatcherTypes(EnumSet.of(
+                DispatcherType.REQUEST,  // 일반 요청
+                DispatcherType.ASYNC,    // 비동기 디스패치 (필요 없으면 제거 가능)
+                DispatcherType.FORWARD   // 내부 포워드 (필요 없으면 제거 가능)
+        ));
+        reg.setAsyncSupported(true);     // 비동기 서블릿 환경에서 안전
+        reg.setOrder(ORDER_EXCEPTION);   // 최상단
+        return reg;
+    }
+
+    /**
+     * JWT 인증 필터
+     * - 경로 정책에 따라 EXCLUDE/OPTIONAL/REQUIRED 모드로 동작
+     * - REQUIRED: 토큰 필수, 실패 시 AppException 던짐 (예외 필터가 JSON 응답으로 변환)
+     * - OPTIONAL: 토큰 있으면 검증/속성세팅, 실패/없어도 통과
+     * - EXCLUDE : 완전 공개, 토큰 무시
+     */
+    @Bean
+    public FilterRegistrationBean<JwtAuthenticationFilter> jwtAuthenticationFilter(
+            JwtProvider jwtProvider,
+            JwtAuthenticationFilterProperties props
+    ) {
+        FilterRegistrationBean<JwtAuthenticationFilter> reg = new FilterRegistrationBean<>();
+        reg.setFilter(new JwtAuthenticationFilter(jwtProvider, props));
+        reg.setName("jwtAuthenticationFilter");
+        reg.addUrlPatterns("/*");
+        reg.setDispatcherTypes(EnumSet.of(
+                DispatcherType.REQUEST,
+                DispatcherType.ASYNC,
+                DispatcherType.FORWARD
+        ));
+        reg.setAsyncSupported(true);
+        reg.setOrder(ORDER_JWT); // 예외 필터 다음
+        return reg;
+    }
+}

--- a/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,253 @@
+package com.friday.commerce.core.web.filter;
+
+import com.friday.commerce.core.security.jwt.JwtProvider;
+import com.friday.commerce.core.security.jwt.TokenException;
+import com.friday.commerce.core.utils.AuthKeys;
+import com.friday.commerce.core.web.exception.AppErrorCode;
+import com.friday.commerce.core.web.exception.AppException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.PathContainer;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
+
+/**
+ * JWT 인증 필터 (Spring Security 미사용)
+ *
+ * <p>경로 정책에 따라 JWT를 처리한다:
+ * - EXCLUDE  : 완전 공개. 토큰이 있어도/깨져도 인증을 시도하지 않고 즉시 통과
+ * - OPTIONAL : 토큰이 있으면 검증 후 request attribute(userId/role) 세팅, 없거나 깨져도 통과
+ * - REQUIRED : 토큰 필수. 없거나 유효하지 않으면 AppException(401) 발생
+ *
+ * <p>검증 성공 시 아래 request attribute를 세팅한다:
+ * - {@code AuthKeys.Attr.USER_ID}  : Long
+ * - {@code AuthKeys.Attr.USER_ROLE}: String(또는 enum을 쓴다면 해당 타입)
+ *
+ * <p>주의:
+ * - 이 필터는 AppException만 던지고, JSON 응답은 상위 {@code ExceptionHandlingFilter}가 표준 포맷으로 변환한다.
+ * - 절대 토큰 원문/민감 정보를 로그에 남기지 않는다.
+ */
+@Slf4j(topic = "JwtAuthenticationFilter")
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+    private final JwtAuthenticationFilterProperties properties;
+
+    private final List<PathPattern> excludePatterns;   // EXCLUDE: 완전 공개
+    private final List<PathPattern> optionalPatterns;  // OPTIONAL: 선택적 인증
+    private final List<PathPattern> includePatterns;   // REQUIRED: 필수 인증
+
+    private final PathPatternParser parser = PathPatternParser.defaultInstance;
+
+    public JwtAuthenticationFilter(JwtProvider jwtProvider,
+            JwtAuthenticationFilterProperties properties) {
+        this.jwtProvider = Objects.requireNonNull(jwtProvider, "jwtProvider");
+        this.properties = Objects.requireNonNull(properties, "properties");
+
+        this.excludePatterns = preparse(properties.getExcludePathPatterns());
+        this.optionalPatterns = preparse(properties.getOptionalPathPatterns());
+        this.includePatterns = preparse(properties.getIncludePathPatterns());
+    }
+
+    /**
+     * 프로퍼티에 적어 둔 패턴 문자열을 PathPattern으로 파싱한다. "/foo/**" → "/foo"도 자동 포함, "/foo/" → "/foo"도 자동 포함.
+     */
+    private List<PathPattern> preparse(List<String> raws) {
+        return raws == null
+                ? List.of()
+                : raws.stream()
+                        .flatMap(this::expandPatternVariants)
+                        .map(parser::parse)
+                        .toList();
+    }
+
+    private Stream<String> expandPatternVariants(String pattern) {
+        Stream<String> stream = Stream.of(pattern);
+
+        // "/foo/**" → "/foo"도 매칭
+        if (pattern.endsWith("/**")) {
+            stream = Stream.concat(stream, Stream.of(pattern.substring(0, pattern.length() - 3)));
+        }
+        // "/foo/" → "/foo"도 매칭
+        if (pattern.endsWith("/") && pattern.length() > 1) {
+            stream = Stream.concat(stream, Stream.of(pattern.substring(0, pattern.length() - 1)));
+        }
+        return stream.distinct();
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        // 모든 요청은 반드시 이 필터를 거친다.
+        return false;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 1) 메서드 제외 (ex: OPTIONS 프리플라이트, HEAD 등)
+        if (isExcludedMethod(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 2) 경로 정책 분류
+        PathClass pathClass = classifyPath(request);
+
+        // 3) EXCLUDE → 완전 공개
+        if (pathClass == PathClass.EXCLUDE) {
+            if (log.isTraceEnabled()) {
+                log.trace("EXCLUDE path -> {}", request.getRequestURI());
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 4) Access Token 추출 (헤더 우선 → 쿠키 fallback)
+        String at = extractAtByHeaderOrCookie(request);
+
+        // 5) REQUIRED → 토큰 필수
+        if (pathClass == PathClass.REQUIRED) {
+            if (!StringUtils.hasText(at)) {
+                throw new AppException(AppErrorCode.TOKEN_REQUIRED);
+            }
+            try {
+                Long userId = jwtProvider.getAtUserId(at);
+                String role = jwtProvider.getAtUserRole(at); // enum을 쓰면 타입을 UserRole로 변경
+
+                if (userId == null || !StringUtils.hasText(role)) {
+                    throw new AppException(AppErrorCode.INVALID_TOKEN);
+                }
+
+                setCurrentUserAttributes(request, userId, role);
+
+            } catch (TokenException te) {
+                // JwtProvider 단계에서 발생한 만료/서명오류/클레임 오류 등
+                throw new AppException(AppErrorCode.AUTHENTICATION_FAILED);
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 6) OPTIONAL → 토큰이 있으면 검증/세팅, 없거나 실패해도 통과
+        if (!StringUtils.hasText(at)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        try {
+            Long userId = jwtProvider.getAtUserId(at);
+            String role = jwtProvider.getAtUserRole(at);
+            if (userId != null && StringUtils.hasText(role)) {
+                setCurrentUserAttributes(request, userId, role);
+            }
+        } catch (TokenException ignore) {
+            // OPTIONAL: 깨진 토큰이면 속성 세팅 없이 그냥 통과
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 경로 정책 분류 (우선순위: EXCLUDE > OPTIONAL > REQUIRED > DEFAULT) DEFAULT는
+     * properties.getDefaultPathPattern()에서 정의한 정책을 따른다.
+     */
+    private PathClass classifyPath(HttpServletRequest request) {
+        String strippedUri = stripContextPath(request.getRequestURI(), request.getContextPath());
+        PathContainer pc = PathContainer.parsePath(strippedUri);
+
+        if (matchesAny(pc, excludePatterns)) {
+            return PathClass.EXCLUDE;
+        }
+        if (matchesAny(pc, optionalPatterns)) {
+            return PathClass.OPTIONAL;
+        }
+        if (matchesAny(pc, includePatterns)) {
+            return PathClass.REQUIRED;
+        }
+
+        // 나머지 전부는 기본 정책으로 처리 (REQUIRED 또는 EXCLUDE)
+        return properties.getDefaultPathPattern(); // 프로퍼티가 PathClass(enum) 반환한다고 가정
+    }
+
+    private boolean matchesAny(PathContainer pc, List<PathPattern> patterns) {
+        for (PathPattern p : patterns) {
+            if (p.matches(pc)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isExcludedMethod(HttpServletRequest request) {
+        List<String> excludeMethods = properties.getExcludeMethods();
+        return excludeMethods != null
+                && excludeMethods.stream().anyMatch(m -> m.equalsIgnoreCase(request.getMethod()));
+    }
+
+    private String stripContextPath(String uri, String ctx) {
+        return (StringUtils.hasLength(ctx) && uri.startsWith(ctx)) ? uri.substring(ctx.length())
+                : uri;
+    }
+
+    /**
+     * AccessToken 추출 (헤더 우선, 없으면 쿠키 fallback).
+     * - Authorization: "Bearer <token>" (대소문자 무시)
+     * - 쿠키: properties.cookieFallback=true일 때만 properties.atCookie 이름으로 검색
+     */
+    private String extractAtByHeaderOrCookie(HttpServletRequest request) {
+        // 1) Authorization 헤더
+        String header = request.getHeader(AUTH_HEADER);
+        if (StringUtils.hasText(header)) {
+            String candidate = header.trim();
+            if (candidate.length() >= BEARER_PREFIX.length()
+                    && candidate.regionMatches(true, 0, BEARER_PREFIX, 0, BEARER_PREFIX.length())) {
+                String token = candidate.substring(BEARER_PREFIX.length()).trim();
+                return StringUtils.hasText(token) ? token : null;
+            }
+        }
+
+        // 2) 쿠키 fallback
+        if (properties.isCookieFallback()) {
+            String cookieName = properties.getAtCookie();
+            if (request.getCookies() != null && StringUtils.hasText(cookieName)) {
+                for (Cookie c : request.getCookies()) {
+                    if (cookieName.equals(c.getName()) && StringUtils.hasText(c.getValue())) {
+                        return c.getValue().trim();
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void setCurrentUserAttributes(HttpServletRequest request, Long userId, String role) {
+        request.setAttribute(AuthKeys.Attr.USER_ID, userId);
+        request.setAttribute(AuthKeys.Attr.USER_ROLE, role);
+        if (log.isDebugEnabled()) {
+            log.debug("JWT OK -> userId={}, role={}, uri={}", userId, role,
+                    request.getRequestURI());
+        }
+    }
+
+    /**
+     * 경로 정책
+     */
+    enum PathClass {
+        EXCLUDE, OPTIONAL, REQUIRED
+    }
+}

--- a/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilter.java
@@ -25,17 +25,16 @@ import org.springframework.web.util.pattern.PathPatternParser;
  * JWT 인증 필터 (Spring Security 미사용)
  *
  * <p>경로 정책에 따라 JWT를 처리한다:
- * - EXCLUDE  : 완전 공개. 토큰이 있어도/깨져도 인증을 시도하지 않고 즉시 통과
- * - OPTIONAL : 토큰이 있으면 검증 후 request attribute(userId/role) 세팅, 없거나 깨져도 통과
- * - REQUIRED : 토큰 필수. 없거나 유효하지 않으면 AppException(401) 발생
+ * - EXCLUDE  : 완전 공개. 토큰이 있어도/깨져도 인증을 시도하지 않고 즉시 통과 - OPTIONAL : 토큰이 있으면 검증 후 request
+ * attribute(userId/role) 세팅, 없거나 깨져도 통과 - REQUIRED : 토큰 필수. 없거나 유효하지 않으면 AppException(401) 발생
  *
  * <p>검증 성공 시 아래 request attribute를 세팅한다:
- * - {@code AuthKeys.Attr.USER_ID}  : Long
- * - {@code AuthKeys.Attr.USER_ROLE}: String(또는 enum을 쓴다면 해당 타입)
+ * - {@code AuthKeys.Attr.USER_ID}  : Long - {@code AuthKeys.Attr.USER_ROLE}: String(또는 enum을 쓴다면 해당
+ * 타입)
  *
  * <p>주의:
- * - 이 필터는 AppException만 던지고, JSON 응답은 상위 {@code ExceptionHandlingFilter}가 표준 포맷으로 변환한다.
- * - 절대 토큰 원문/민감 정보를 로그에 남기지 않는다.
+ * - 이 필터는 AppException만 던지고, JSON 응답은 상위 {@code ExceptionHandlingFilter}가 표준 포맷으로 변환한다. - 절대 토큰
+ * 원문/민감 정보를 로그에 남기지 않는다.
  */
 @Slf4j(topic = "JwtAuthenticationFilter")
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -78,8 +77,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Stream<String> stream = Stream.of(pattern);
 
         // "/foo/**" → "/foo"도 매칭
-        if (pattern.endsWith("/**")) {
-            stream = Stream.concat(stream, Stream.of(pattern.substring(0, pattern.length() - 3)));
+        if (pattern.endsWith("/**") && pattern.length() > 3) {
+            String trimmed = pattern.substring(0, pattern.length() - 3);
+            if (StringUtils.hasText(trimmed)) {
+                stream = Stream.concat(stream, Stream.of(trimmed));
+            }
         }
         // "/foo/" → "/foo"도 매칭
         if (pattern.endsWith("/") && pattern.length() > 1) {
@@ -205,9 +207,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * AccessToken 추출 (헤더 우선, 없으면 쿠키 fallback).
-     * - Authorization: "Bearer <token>" (대소문자 무시)
-     * - 쿠키: properties.cookieFallback=true일 때만 properties.atCookie 이름으로 검색
+     * AccessToken 추출 (헤더 우선, 없으면 쿠키 fallback). - Authorization: "Bearer <token>" (대소문자 무시) - 쿠키:
+     * properties.cookieFallback=true일 때만 properties.atCookie 이름으로 검색
      */
     private String extractAtByHeaderOrCookie(HttpServletRequest request) {
         // 1) Authorization 헤더

--- a/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilterProperties.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilterProperties.java
@@ -17,7 +17,7 @@ public class JwtAuthenticationFilterProperties {
     private List<String> includePathPatterns = new ArrayList<>();
     private PathClass defaultPathPattern = PathClass.REQUIRED;
 
-    private List<String> excludeMethods = List.of();
+    private List<String> excludeMethods = new ArrayList<>();
     private boolean cookieFallback = false;
     private String atCookie = "Access-Token";
 }

--- a/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilterProperties.java
+++ b/src/main/java/com/friday/commerce/core/web/filter/JwtAuthenticationFilterProperties.java
@@ -1,0 +1,23 @@
+package com.friday.commerce.core.web.filter;
+
+import com.friday.commerce.core.web.filter.JwtAuthenticationFilter.PathClass;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@ConfigurationProperties(prefix = "security.jwt.filter")
+@Component
+public class JwtAuthenticationFilterProperties {
+
+    private List<String> excludePathPatterns = new ArrayList<>();
+    private List<String> optionalPathPatterns = new ArrayList<>();
+    private List<String> includePathPatterns = new ArrayList<>();
+    private PathClass defaultPathPattern = PathClass.REQUIRED;
+
+    private List<String> excludeMethods = List.of();
+    private boolean cookieFallback = false;
+    private String atCookie = "Access-Token";
+}

--- a/src/main/java/com/friday/commerce/core/web/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/friday/commerce/core/web/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,187 @@
+package com.friday.commerce.core.web.resolver;
+
+import static com.friday.commerce.core.utils.AuthKeys.Attr.USER_ID;
+import static com.friday.commerce.core.utils.AuthKeys.Attr.USER_ROLE;
+import static com.friday.commerce.core.utils.AuthKeys.Header.HDR_USER_ID;
+import static com.friday.commerce.core.utils.AuthKeys.Header.HDR_USER_ROLE;
+
+import com.friday.commerce.core.security.annotation.CurrentUser;
+import com.friday.commerce.core.security.model.CurrentUserInfo;
+import com.friday.commerce.core.security.model.UserRole;
+import com.friday.commerce.core.web.exception.AppErrorCode;
+import com.friday.commerce.core.web.exception.AppException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Slf4j(topic = "CurrentUserArgumentResolver")
+@RequiredArgsConstructor
+@Component
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Value("${security.current-user.allow-header-fallback:false}")
+    private boolean allowHeaderFallback;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        if (!parameter.hasParameterAnnotation(CurrentUser.class)) {
+            return false;
+        }
+
+        Class<?> type = parameter.getParameterType();
+        if (CurrentUserInfo.class.isAssignableFrom(type)) {
+            return true;
+        }
+
+        if (Optional.class.isAssignableFrom(type)) {
+            Type g = parameter.getGenericParameterType();
+            if (g instanceof ParameterizedType pt) {
+                Type arg = pt.getActualTypeArguments()[0];
+                if (arg instanceof Class<?> c && CurrentUserInfo.class.isAssignableFrom(c)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory
+    ) {
+        HttpServletRequest req = webRequest.getNativeRequest(HttpServletRequest.class);
+        if (req == null) {
+            throw new AppException(AppErrorCode.REQUEST_CONTEXT_NOT_FOUND);
+        }
+
+        boolean wantsOptional = Optional.class.isAssignableFrom(parameter.getParameterType());
+
+        CurrentUserInfo info = extractCurrentUser(req);
+
+        if (wantsOptional) {
+            return Optional.ofNullable(info);
+        }
+
+        if (info == null) {
+            // 인증 정보가 전혀 없는 경우(익명) → 401
+            throw new AppException(AppErrorCode.UNAUTHORIZED);
+        }
+        return info;
+    }
+
+    /**
+     * attribute 우선, 필요 시(설정에 따라) header fallback
+     */
+    private CurrentUserInfo extractCurrentUser(HttpServletRequest req) {
+        Object idAttr = req.getAttribute(USER_ID);
+        Object roleAttr = req.getAttribute(USER_ROLE);
+
+        Long userId = coerceUserId(idAttr);
+        UserRole role = coerceUserRole(roleAttr);
+
+        if (userId == null || role == null) {
+            if (allowHeaderFallback) {
+                if (userId == null) {
+                    userId = parseUserIdHeader(req.getHeader(HDR_USER_ID));
+                }
+                if (role == null) {
+                    role = parseUserRoleHeader(req.getHeader(HDR_USER_ROLE));
+                }
+            }
+        }
+
+        if (userId == null && role == null) {
+            return null; // 완전 익명
+        }
+        if (userId == null) {
+            throw new AppException(AppErrorCode.MISSING_HEADER_USER_ID);
+        }
+        if (role == null) {
+            throw new AppException(AppErrorCode.MISSING_HEADER_USER_ROLE);
+        }
+
+        try {
+            return CurrentUserInfo.of(userId, role);
+        } catch (IllegalArgumentException e) {
+            throw new AppException(AppErrorCode.INVALID_USER_INFO);
+        }
+    }
+
+    private Long coerceUserId(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof Long l) {
+            return l;
+        }
+        if (v instanceof Integer i) {
+            return i.longValue();
+        }
+        if (v instanceof String s) {
+            try {
+                return Long.parseLong(s.trim());
+            } catch (NumberFormatException ignore) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private UserRole coerceUserRole(Object v) {
+        if (v == null) {
+            return null;
+        }
+        if (v instanceof UserRole r) {
+            return r;
+        }
+        if (v instanceof String s) {
+            return toUserRoleOrNull(s);
+        }
+        return null;
+    }
+
+    private Long parseUserIdHeader(String headerVal) {
+        if (headerVal == null || headerVal.isBlank()) {
+            return null;
+        }
+        try {
+            return Long.parseLong(headerVal.trim());
+        } catch (NumberFormatException e) {
+            throw new AppException(AppErrorCode.INVALID_HEADER_USER_ID_NOT_INTEGER);
+        }
+    }
+
+    private UserRole parseUserRoleHeader(String headerVal) {
+        if (headerVal == null || headerVal.isBlank()) {
+            return null;
+        }
+        UserRole r = toUserRoleOrNull(headerVal);
+        if (r == null) {
+            throw new AppException(AppErrorCode.INVALID_HEADER_USER_ROLE);
+        }
+        return r;
+    }
+
+    private UserRole toUserRoleOrNull(String s) {
+        try {
+            return UserRole.valueOf(s.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,3 +137,19 @@ auth:
     max-attempts: 5                     # 최대 인증 시도
     lockout-duration: 10m               # 시도 초과 차단 시간
     success-validity-duration: 10m      # 검증 성공 플래그 TTL
+
+
+security:
+  current-user:
+    allow-header-fallback: false
+
+  jwt:
+    filter:
+      default-path-pattern: REQUIRED
+      exclude-path-patterns:
+        - /actuator/**
+        - /docs/**
+      optional-path-patterns:
+        - /users/**
+      include-path-patterns:
+        /api/**


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [ ] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- Resolver, Filter 를 구현해서 사용자 정보를 주입 받을 수 있는 파라미터 레벨의 애너테이션을 구현했습니다.
- Filter 는 EXCLUDE, OPTIONAL, REQUIRED 세 개의 경로 정책에 따라서 JWT 필요 여부를 구분 했습니다.

## 🔍 관련 이슈
- Closes #40

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - JWT 기반 인증 필터 도입: 경로별(필수/선택/제외) 인증 적용, 토큰은 기본적으로 Authorization 헤더 사용(쿠키 폴백 옵션 지원).
  - 전역 예외 처리 필터 추가: 일관된 JSON 오류 응답(타임스탬프/상태/코드/메시지/경로) 제공.
  - 컨트롤러에서 현재 사용자 정보를 주입받을 수 있는 기능 추가.
- 개선/변경
  - 인증/요청 검증 관련 오류 코드 확장(예: 잘못된/누락된 사용자 식별자 등).
  - 기본 설정 제공: 특정 경로 인증 제외(/actuator/**, /docs/**), 선택 인증(/users/**), 포함(/api/**); 헤더 폴백 기본 비활성화.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->