### PR TITLE
User: 회원 비밀번호 변경 

### DIFF
--- a/src/main/java/com/friday/commerce/user/application/dto/user/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/friday/commerce/user/application/dto/user/request/UpdatePasswordRequest.java
@@ -1,0 +1,27 @@
+package com.friday.commerce.user.application.dto.user.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdatePasswordRequest(
+        @NotBlank(message = "비밀번호: 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:\";'<>?,./]).{8,}$",
+                message = "비밀번호: 최소 8자, 영문자/숫자/특수문자를 각각 1개 이상 포함해야 합니다."
+        )
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String password,
+
+        @NotBlank(message = "비밀번호: 비밀번호는 필수입니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-={}|\\[\\]:\";'<>?,./]).{8,}$",
+                message = "비밀번호: 최소 8자, 영문자/숫자/특수문자를 각각 1개 이상 포함해야 합니다."
+        )
+        @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+        String newPassword,
+
+        String rt
+) {
+
+}

--- a/src/main/java/com/friday/commerce/user/application/dto/user/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/friday/commerce/user/application/dto/user/request/UpdatePasswordRequest.java
@@ -21,6 +21,7 @@ public record UpdatePasswordRequest(
         @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
         String newPassword,
 
+        @NotBlank(message = "리프레시 토큰: 토큰은 필수입니다.")
         String rt
 ) {
 

--- a/src/main/java/com/friday/commerce/user/application/service/UserService.java
+++ b/src/main/java/com/friday/commerce/user/application/service/UserService.java
@@ -351,6 +351,11 @@ class UserService implements AuthUseCase, UserUseCase {
             UpdatePasswordRequest request) {
         User user = findUserById(info.userId());
 
+        // RT 확인
+        if (!StringUtils.hasText(request.rt())) {
+            throw new UserException(UserErrorCode.RT_NOT_FOUND);
+        }
+
         // 비밀번호 재확인
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new UserException(UserErrorCode.PASSWORD_INCORRECT);

--- a/src/main/java/com/friday/commerce/user/application/service/UserService.java
+++ b/src/main/java/com/friday/commerce/user/application/service/UserService.java
@@ -16,6 +16,7 @@ import com.friday.commerce.user.application.dto.auth.response.SendCodeEmailRespo
 import com.friday.commerce.user.application.dto.auth.response.SignInResponse;
 import com.friday.commerce.user.application.dto.auth.response.SignUpResponse;
 import com.friday.commerce.user.application.dto.auth.response.VerifyCodeEmailResponse;
+import com.friday.commerce.user.application.dto.user.request.UpdatePasswordRequest;
 import com.friday.commerce.user.application.dto.user.response.GetUserResponse;
 import com.friday.commerce.user.application.usecase.AuthUseCase;
 import com.friday.commerce.user.application.usecase.UserUseCase;
@@ -29,6 +30,7 @@ import com.friday.commerce.user.domain.port.EmailVerificationRepositoryPort;
 import com.friday.commerce.user.domain.port.TokenProvider;
 import com.friday.commerce.user.domain.port.UserCacheRepository;
 import com.friday.commerce.user.domain.repository.UserRepository;
+import jakarta.annotation.Nullable;
 import java.security.SecureRandom;
 import java.util.Locale;
 import java.util.Map;
@@ -160,31 +162,7 @@ class UserService implements AuthUseCase, UserUseCase {
     @Transactional
     @Override
     public void logout(String authHeader, LogoutRequest request) {
-        // 토큰으로부터 회원 ID 추출
-        Long rtUserId = tokenProvider.getRtUserId(request.rt());
-
-        // 토큰(at, rt)에서 jti 추출 -> JwtProvider
-        String atJti = tokenProvider.getAtJti(authHeader);
-        String rtJti = tokenProvider.getRtJti(request.rt());
-
-        // 레디스 안에 RT 토큰과 요청 토큰의 jti 일치하는 지 확인 및 조회
-        String getRtJti = userCacheRepository.getRtJti(rtUserId)
-                .orElseThrow(() -> new UserException(UserErrorCode.RT_NOT_FOUND));
-
-        if (!getRtJti.equals(rtJti)) {
-            throw new UserException(UserErrorCode.RT_JTI_INCORRECT);
-        }
-
-        // 토큰(at, rt)에서 남은 시간 추출 -> JwtProvider
-        long atTtlMs = tokenProvider.getAtTtlMs(authHeader);
-        long rtTtlMs = tokenProvider.getRtTtlMs(request.rt());
-
-        // 토큰(at, rt)을 블랙리스트로 등록 -> JwtProvider
-        userCacheRepository.atSetBl(atJti, atTtlMs);
-        userCacheRepository.rtSetBl(rtJti, rtTtlMs);
-
-        // 토큰 삭제(rt) -> JwtProvider
-        userCacheRepository.deleteRt(rtUserId);
+        invalidateSession(authHeader, request.rt());
     }
 
     @Transactional
@@ -366,5 +344,55 @@ class UserService implements AuthUseCase, UserUseCase {
 
         return GetUserResponse.from(userById);
     }
+
+    @Transactional
+    @Override
+    public void updatePassword(String authHeader, CurrentUserInfo info,
+            UpdatePasswordRequest request) {
+        User user = findUserById(info.userId());
+
+        // 비밀번호 재확인
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new UserException(UserErrorCode.PASSWORD_INCORRECT);
+        }
+
+        // 비밀번호가 이전과 동일한 지
+        if (passwordEncoder.matches(request.newPassword(), user.getPassword())) {
+            throw new UserException(UserErrorCode.PASSWORD_SAME_BEFORE);
+        }
+
+        // 새로운 비밀번호로 변경
+        user.updatePassword(passwordEncoder.encode(request.newPassword()), info.userId());
+
+        // 강제 로그아웃: 이전 AT, RT 무효화
+        invalidateSession(authHeader, request.rt());
+    }
+
+    // 검증 + 블랙리스트 등록 + RT 삭제까지 한 번에
+    private void invalidateSession(@Nullable String authHeader, String rt) {
+        // RT JTI, 회원 ID 추출
+        Long userId = tokenProvider.getRtUserId(rt);
+        String rtJti = tokenProvider.getRtJti(rt);
+
+        // RT JTI 일치 여부 확인(세션 탈취 방지를 위한 핵심)
+        String storedRtJti = userCacheRepository.getRtJti(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.RT_NOT_FOUND));
+        if (!storedRtJti.equals(rtJti)) throw new UserException(UserErrorCode.RT_JTI_INCORRECT);
+
+        // RT 블랙리스트 등록
+        long rtTtlMs = tokenProvider.getRtTtlMs(rt);
+        userCacheRepository.rtSetBl(rtJti, rtTtlMs);
+
+        // AT가 있으면 함께 블랙리스트
+        if (StringUtils.hasText(authHeader)) {
+            String atJti = tokenProvider.getAtJti(authHeader);
+            long atTtlMs = tokenProvider.getAtTtlMs(authHeader);
+            userCacheRepository.atSetBl(atJti, atTtlMs);
+        }
+
+        userCacheRepository.deleteRt(userId);
+    }
+
+
 }
 

--- a/src/main/java/com/friday/commerce/user/application/usecase/UserUseCase.java
+++ b/src/main/java/com/friday/commerce/user/application/usecase/UserUseCase.java
@@ -1,9 +1,12 @@
 package com.friday.commerce.user.application.usecase;
 
 import com.friday.commerce.core.security.model.CurrentUserInfo;
+import com.friday.commerce.user.application.dto.user.request.UpdatePasswordRequest;
 import com.friday.commerce.user.application.dto.user.response.GetUserResponse;
 
 public interface UserUseCase {
 
     GetUserResponse getUser(CurrentUserInfo info);
+
+    void updatePassword(String authHeader, CurrentUserInfo info, UpdatePasswordRequest request);
 }

--- a/src/main/java/com/friday/commerce/user/domain/entity/User.java
+++ b/src/main/java/com/friday/commerce/user/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.friday.commerce.user.domain.entity;
 
+import com.friday.commerce.user.domain.exception.UserErrorCode;
+import com.friday.commerce.user.domain.exception.UserException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -177,5 +179,18 @@ public class User {
             case SELLER -> com.friday.commerce.core.security.model.UserRole.SELLER;
             case ADMIN -> com.friday.commerce.core.security.model.UserRole.ADMIN;
         };
+    }
+
+    public void updatePassword(String newPassword, Long userId) {
+        if (newPassword == null || newPassword.isEmpty()) {
+            throw new UserException(UserErrorCode.PASSWORD_NULL);
+        }
+        this.password = newPassword;
+        updated(userId);
+    }
+
+    private void updated(Long userId) {
+        this.updatedAt = LocalDateTime.now();
+        this.updatedBy = userId;
     }
 }

--- a/src/main/java/com/friday/commerce/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/friday/commerce/user/domain/exception/UserErrorCode.java
@@ -15,7 +15,7 @@ public enum UserErrorCode implements ErrorCode {
     RT_BLACKLIST(HttpStatus.FORBIDDEN, "회원: 해당 RT 토큰은 블랙리스트로 등록되어 있습니다."),
     AT_BLACKLIST(HttpStatus.FORBIDDEN, "회원: 해당 AT 토큰은 블랙리스트로 등록되어 있습니다."),
 
-
+    PASSWORD_SAME_BEFORE(HttpStatus.BAD_REQUEST, "비밀번호: 이전 비밀번호와 동일한 비밀번호 입니다."),
     PASSWORD_INVALID(HttpStatus.BAD_REQUEST, "비밀번호: 비밀번호 형식이 올바르지 않습니다."),
     PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "비밀번호: 비밀번호가 틀립니다."),
     PASSWORD_NULL(HttpStatus.BAD_REQUEST, "비밀번호: 비밀번호 입력은 필수입니다."),

--- a/src/main/java/com/friday/commerce/user/presentation/UserController.java
+++ b/src/main/java/com/friday/commerce/user/presentation/UserController.java
@@ -4,12 +4,17 @@ import com.friday.commerce.core.security.annotation.CurrentUser;
 import com.friday.commerce.core.security.annotation.RequireRole;
 import com.friday.commerce.core.security.model.CurrentUserInfo;
 import com.friday.commerce.core.security.model.UserRole;
+import com.friday.commerce.user.application.dto.user.request.UpdatePasswordRequest;
 import com.friday.commerce.user.application.dto.user.response.GetUserResponse;
 import com.friday.commerce.user.application.usecase.UserUseCase;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +35,20 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
+    }
+
+    @RequireRole({UserRole.USER, UserRole.SELLER, UserRole.ADMIN})
+    @PatchMapping("/password")
+    public ResponseEntity<Void> updatePassword(
+            @RequestHeader(name = "Authorization", required = false, defaultValue = "") String authHeader,
+            @CurrentUser CurrentUserInfo info,
+            @RequestBody @Valid UpdatePasswordRequest request
+    ) {
+        userUseCase.updatePassword(authHeader, info, request);
+
+        return ResponseEntity
+                .noContent()
+                .build();
     }
 
 }

--- a/src/test/java/com/friday/commerce/http/user/user-update-password.http
+++ b/src/test/java/com/friday/commerce/http/user/user-update-password.http
@@ -1,0 +1,63 @@
+@baseUrl = http://localhost:10000
+
+### @name SignUp_Success
+# 정상 회원가입 시나리오
+POST {{baseUrl}}/api/v1/auth/sign-up
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456",
+  "username": "앨리스123",
+  "agreement": {
+    "termsOfService": true,
+    "privacy": true,
+    "marketing": true
+  },
+  "address": {
+    "zipCode": "06236",
+    "addressLine1": "서울시 강남구 테헤란로 123",
+    "addressLine2": "OO빌딩 5층",
+    "city": "서울",
+    "state": "강남구"
+  }
+}
+
+
+### 로그인 성공 시나리오
+POST http://localhost:10000/api/v1/auth/sign-in
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456"
+}
+
+> {%
+  client.global.set("userId", response.body.userId.toFixed(0))
+  client.global.set("at", response.body.at)
+  client.global.set("rt", response.body.rt)
+%}
+
+### 마이페이지 조회
+GET {{baseUrl}}/api/v1/users/me
+Content-Type: application/json
+Authorization: Bearer {{at}}
+Accept: application/json
+
+{
+
+}
+
+### 새로운 비밀번호로 변경
+PATCH http://localhost:10000/api/v1/users/password
+Content-Type: application/json
+Authorization: Bearer {{at}}
+Accept: application/json
+
+{
+  "password": "Bb@12345",
+  "newPassword": "Bb@12345"
+}


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 비밀번호 변경을 구현했습니다.
- 변경 이후 강제 로그아웃되고, 이전에 구현한 로그아웃 기능을 메서드로 분리하여 사용할 수 있도록 작성했습니다.

## 🔍 관련 이슈
- Closes #50

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 로그인 사용자를 위한 비밀번호 변경 기능 추가. 변경 완료 시 기존 모든 세션/토큰이 즉시 무효화되어 자동 로그아웃됩니다.
  - 비밀번호 정책 강화: 최소 8자, 영문/숫자/특수문자 각 1자 이상 필수. 현재 비밀번호와 동일한 비밀번호로는 변경할 수 없습니다.
- 테스트
  - 회원가입, 로그인, 내 정보 조회, 비밀번호 변경을 아우르는 E2E HTTP 시나리오를 추가해 주요 사용자 흐름을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->