### PR TITLE
User: 불필요한 헤더 파싱 삭제

### DIFF
--- a/src/main/java/com/friday/commerce/user/application/service/UserService.java
+++ b/src/main/java/com/friday/commerce/user/application/service/UserService.java
@@ -391,7 +391,7 @@ class UserService implements AuthUseCase, UserUseCase {
 
     @Transactional
     @Override
-    public SendCodeEmailResponse updateEmail(String authHeader, CurrentUserInfo info,
+    public SendCodeEmailResponse updateEmail(CurrentUserInfo info,
             UpdateEmailRequest request) {
         final String newEmail = normalizeEmail(request.newEmail());
         User user = findUserById(info.userId());

--- a/src/main/java/com/friday/commerce/user/application/usecase/UserUseCase.java
+++ b/src/main/java/com/friday/commerce/user/application/usecase/UserUseCase.java
@@ -14,7 +14,7 @@ public interface UserUseCase {
 
     void updatePassword(String authHeader, CurrentUserInfo info, UpdatePasswordRequest request);
 
-    SendCodeEmailResponse updateEmail(String authHeader, CurrentUserInfo info, UpdateEmailRequest request);
+    SendCodeEmailResponse updateEmail(CurrentUserInfo info, UpdateEmailRequest request);
 
     void confirmUpdateEmail(String authHeader, CurrentUserInfo info, UpdateEmailConfirmRequest request);
 }

--- a/src/main/java/com/friday/commerce/user/presentation/UserController.java
+++ b/src/main/java/com/friday/commerce/user/presentation/UserController.java
@@ -58,18 +58,17 @@ public class UserController {
     @RequireRole({UserRole.USER, UserRole.SELLER, UserRole.ADMIN})
     @PatchMapping("/email")
     public ResponseEntity<SendCodeEmailResponse> updateEmail(
-            @RequestHeader(name = "Authorization", required = false, defaultValue = "") String authHeader,
             @CurrentUser CurrentUserInfo info,
             @RequestBody @Valid UpdateEmailRequest request
             ) {
-        SendCodeEmailResponse response = userUseCase.updateEmail(authHeader, info, request);
+        SendCodeEmailResponse response = userUseCase.updateEmail(info, request);
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
     }
 
-    @PostMapping("email/confirm")
+    @PostMapping("/email/confirm")
     public ResponseEntity<Void> confirmEmailChange(
             @RequestHeader(value = "Authorization", required = false) String authHeader,
             @CurrentUser CurrentUserInfo info,


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

- 개선과 함께 더이상 사용되지 않은 불필요한 헤더 at 파싱을 삭제합니다.

## 🔍 관련 이슈
- Closes #54

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 이메일 업데이트 엔드포인트 호출 시 Authorization 헤더 입력이 더 이상 필요하지 않도록 단순화했습니다. 클라이언트는 사용자 정보와 요청 본문만으로 호출할 수 있습니다.
  - 이메일 변경 확인 엔드포인트 경로를 /email/confirm 로 정규화했습니다. 기존 경로를 사용 중인 클라이언트는 새 경로로 업데이트가 필요합니다.
  - 내부 인터페이스/서비스 시그니처를 위 변경사항에 맞춰 일관되게 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->