### PR TITLE
Category: 카테고리 삭제 

### DIFF
--- a/src/main/java/com/friday/commerce/catalog/application/dto/category/response/DeleteCategoryResponse.java
+++ b/src/main/java/com/friday/commerce/catalog/application/dto/category/response/DeleteCategoryResponse.java
@@ -1,0 +1,21 @@
+package com.friday.commerce.catalog.application.dto.category.response;
+
+import com.friday.commerce.catalog.domain.entity.Category;
+
+public record DeleteCategoryResponse(
+        Long categoryId,
+        Long parentId,
+        String path,
+        Integer depth,
+        boolean deleted
+) {
+
+    public static DeleteCategoryResponse of(Category category) {
+        Long pid = (category.getParent() == null) ? null : category.getParent().getCategoryId();
+        return new DeleteCategoryResponse(
+                category.getCategoryId(), pid,
+                category.getPath(),
+                category.getDepth(), true
+        );
+    }
+}

--- a/src/main/java/com/friday/commerce/catalog/application/service/CategoryService.java
+++ b/src/main/java/com/friday/commerce/catalog/application/service/CategoryService.java
@@ -3,6 +3,7 @@ package com.friday.commerce.catalog.application.service;
 import com.friday.commerce.catalog.application.dto.category.request.CreateCategoryRequest;
 import com.friday.commerce.catalog.application.dto.category.request.UpdateCategoryNameRequest;
 import com.friday.commerce.catalog.application.dto.category.response.CreateCategoryResponse;
+import com.friday.commerce.catalog.application.dto.category.response.DeleteCategoryResponse;
 import com.friday.commerce.catalog.application.dto.category.response.GetAllCategoriesResponse;
 import com.friday.commerce.catalog.application.dto.category.response.UpdateCategoryNameResponse;
 import com.friday.commerce.catalog.application.usecase.CategoryUseCase;
@@ -67,7 +68,7 @@ public class CategoryService implements CategoryUseCase {
         int startingDepth = 0;
 
         if (request.startParentId() != null) {
-            currentParent = findCategoryById(request.startParentId());
+            currentParent = mustGetActive(request.startParentId());
             startingDepth = currentParent.getDepth();
         }
 
@@ -83,8 +84,8 @@ public class CategoryService implements CategoryUseCase {
         for (String name : tokens) {
             // 1) 존재 여부 확인
             Optional<Category> existing = (last == null)
-                    ? categoryRepository.findByParentIsNullAndName(name)
-                    : categoryRepository.findByParentAndName(last, name);
+                    ? categoryRepository.findByParentIsNullAndNameAndDeletedAtIsNull(name)
+                    : categoryRepository.findByParentAndNameAndDeletedAtIsNull(last, name);
 
             if (existing.isPresent()) {
                 last = existing.get();
@@ -159,6 +160,26 @@ public class CategoryService implements CategoryUseCase {
         // dirty checking 으로 flush
 
         return toNameResponse(category);
+    }
+
+    @Transactional
+    @Override
+    public DeleteCategoryResponse deleteCategory(Long categoryId, CurrentUserInfo info) {
+        // 1) 활성 카테고리만 대상 (이미 삭제된 것은 404로 본다)
+        Category category = mustGetActive(categoryId);
+
+        // 2) 활성 자식 존재하면 삭제 불가
+        long childCount = categoryRepository.countByParentAndDeletedAtIsNull(category);
+        if (childCount > 0) {
+            throw new ProductException(ProductErrorCode.CATEGORY_HAS_CHILDREN);
+        }
+
+        // 3) 소프트 삭제
+        category.softDelete(info.userId());
+        // JPA dirty checking 으로 반영됨
+
+        // 4) 응답: 표준 필드 그대로
+        return DeleteCategoryResponse.of(category);
     }
 
     private UpdateCategoryNameResponse toNameResponse(Category category) {

--- a/src/main/java/com/friday/commerce/catalog/application/usecase/CategoryUseCase.java
+++ b/src/main/java/com/friday/commerce/catalog/application/usecase/CategoryUseCase.java
@@ -3,10 +3,10 @@ package com.friday.commerce.catalog.application.usecase;
 import com.friday.commerce.catalog.application.dto.category.request.CreateCategoryRequest;
 import com.friday.commerce.catalog.application.dto.category.request.UpdateCategoryNameRequest;
 import com.friday.commerce.catalog.application.dto.category.response.CreateCategoryResponse;
+import com.friday.commerce.catalog.application.dto.category.response.DeleteCategoryResponse;
 import com.friday.commerce.catalog.application.dto.category.response.GetAllCategoriesResponse;
 import com.friday.commerce.catalog.application.dto.category.response.UpdateCategoryNameResponse;
 import com.friday.commerce.core.security.model.CurrentUserInfo;
-import jakarta.validation.Valid;
 
 public interface CategoryUseCase {
 
@@ -15,4 +15,6 @@ public interface CategoryUseCase {
     GetAllCategoriesResponse getAllCategories(String format, Integer maxDepth);
 
     UpdateCategoryNameResponse updateName(Long categoryId,  UpdateCategoryNameRequest request, CurrentUserInfo info);
+
+    DeleteCategoryResponse deleteCategory(Long categoryId, CurrentUserInfo info);
 }

--- a/src/main/java/com/friday/commerce/catalog/domain/entity/Category.java
+++ b/src/main/java/com/friday/commerce/catalog/domain/entity/Category.java
@@ -143,4 +143,9 @@ public class Category {
         this.updatedAt = java.time.LocalDateTime.now();
         this.updatedBy = updatedBy;
     }
+
+    public void softDelete(Long deletedBy) {
+        this.deletedAt = java.time.LocalDateTime.now();
+        this.deletedBy = deletedBy;
+    }
 }

--- a/src/main/java/com/friday/commerce/catalog/domain/exception/ProductErrorCode.java
+++ b/src/main/java/com/friday/commerce/catalog/domain/exception/ProductErrorCode.java
@@ -53,9 +53,9 @@ public enum ProductErrorCode implements ErrorCode {
     CATEGORY_PATH_INVALID(HttpStatus.BAD_REQUEST, "카테고리: 경로가 올바르지 않습니다."),
     CATEGORY_CYCLE_DETECTED(HttpStatus.BAD_REQUEST, "카테고리: 순환 참조가 감지되었습니다."),
     CATEGORY_PARENT_NULL(HttpStatus.BAD_REQUEST, "카테고리: 부모 카테고리가 NULL 입니니다."),
+    CATEGORY_HAS_CHILDREN(HttpStatus.BAD_REQUEST, "카테고리: 하위 카테고리가 있어 삭제할 수 없습니다."),
     PRODUCT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 연결: 상품-카테고리 연결을 찾을 수 없습니다."),
     PRODUCT_CATEGORY_DUPLICATED(HttpStatus.CONFLICT, "카테고리 연결: 이미 연결된 카테고리입니다."),
-
 
     // ===== 내용 정제/포맷 =====
     CONTENT_HTML_SANITIZE_FAILED(HttpStatus.BAD_REQUEST, "콘텐츠: HTML 정제 과정에서 오류가 발생했습니다."),

--- a/src/main/java/com/friday/commerce/catalog/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/friday/commerce/catalog/domain/repository/CategoryRepository.java
@@ -21,4 +21,10 @@ public interface CategoryRepository {
     boolean existsByParentIsNullAndNameAndDeletedAtIsNull(String newName);
 
     boolean existsByParentAndNameAndDeletedAtIsNull(Category parent, String newName);
+
+    long countByParentAndDeletedAtIsNull(Category parent);
+
+    Optional<Category> findByParentIsNullAndNameAndDeletedAtIsNull(String name);
+    Optional<Category> findByParentAndNameAndDeletedAtIsNull(Category parent, String name);
+
 }

--- a/src/main/java/com/friday/commerce/catalog/presentation/CategoryController.java
+++ b/src/main/java/com/friday/commerce/catalog/presentation/CategoryController.java
@@ -3,6 +3,7 @@ package com.friday.commerce.catalog.presentation;
 import com.friday.commerce.catalog.application.dto.category.request.CreateCategoryRequest;
 import com.friday.commerce.catalog.application.dto.category.request.UpdateCategoryNameRequest;
 import com.friday.commerce.catalog.application.dto.category.response.CreateCategoryResponse;
+import com.friday.commerce.catalog.application.dto.category.response.DeleteCategoryResponse;
 import com.friday.commerce.catalog.application.dto.category.response.GetAllCategoriesResponse;
 import com.friday.commerce.catalog.application.dto.category.response.UpdateCategoryNameResponse;
 import com.friday.commerce.catalog.application.usecase.CategoryUseCase;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -67,6 +69,19 @@ public class CategoryController {
     ) {
         UpdateCategoryNameResponse response = categoryUseCase.updateName(categoryId, request, info);
         return ResponseEntity.status(HttpStatus.OK)
+                .body(response);
+    }
+
+    // 카테고리 삭제
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<DeleteCategoryResponse> deleteCategory(
+            @PathVariable Long categoryId,
+            @CurrentUser CurrentUserInfo info
+    ) {
+        DeleteCategoryResponse response = categoryUseCase.deleteCategory(categoryId, info);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
                 .body(response);
     }
 }

--- a/src/main/java/com/friday/commerce/catalog/presentation/CategoryController.java
+++ b/src/main/java/com/friday/commerce/catalog/presentation/CategoryController.java
@@ -61,6 +61,7 @@ public class CategoryController {
 
 
     // 카테고리명 수정
+    @RequireRole({UserRole.ADMIN, UserRole.SELLER})
     @PatchMapping("/{categoryId}/name")
     public ResponseEntity<UpdateCategoryNameResponse> updateCategoryName(
             @PathVariable Long categoryId,
@@ -73,6 +74,7 @@ public class CategoryController {
     }
 
     // 카테고리 삭제
+    @RequireRole({UserRole.ADMIN, UserRole.SELLER})
     @DeleteMapping("/{categoryId}")
     public ResponseEntity<DeleteCategoryResponse> deleteCategory(
             @PathVariable Long categoryId,

--- a/src/test/java/com/friday/commerce/http/category/category-delete.http
+++ b/src/test/java/com/friday/commerce/http/category/category-delete.http
@@ -1,0 +1,115 @@
+@baseUrl = http://localhost:10000
+
+### @name SignUp_Success
+# 정상 회원가입 시나리오
+POST {{baseUrl}}/api/v1/auth/sign-up
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456",
+  "username": "앨리스123",
+  "agreement": {
+    "termsOfService": true,
+    "privacy": true,
+    "marketing": true
+  },
+  "address": {
+    "zipCode": "06236",
+    "addressLine1": "서울시 강남구 테헤란로 123",
+    "addressLine2": "OO빌딩 5층",
+    "city": "서울",
+    "state": "강남구"
+  }
+}
+
+
+### 로그인 성공 시나리오
+POST http://localhost:10000/api/v1/auth/sign-in
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456"
+}
+
+> {%
+  client.global.set("userId", response.body.userId.toFixed(0))
+  client.global.set("at", response.body.at)
+  client.global.set("rt", response.body.rt)
+%}
+
+
+### 카테고리 생성(startParentId, maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+  "path": "남자/상의/셔츠",
+  "delimiter": "/"
+}
+
+### 카테고리 생성(maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "셔츠/린넨",
+"delimiter": "/",
+"startParentId": 3665007757758464
+}
+
+### 카테고리 생성(다른 구분자, startParentId, maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "여자>아우터>자켓",
+"delimiter": ">",
+"startParentId": null,
+"maxDepthOverride": null
+}
+
+### 카테고리 생성(최대 요청 하드리밋. startParentId: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "스포츠/축구/유니폼/상의/반팔/나이키/24시즌",
+"delimiter": "/",
+"startParentId": null,
+"maxDepthOverride": 7
+}
+
+### 카테고리 삭제
+DELETE {{baseUrl}}/api/v1/categories/4062598412636160
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+
+}
+
+### 카테고리 조회(전체 트리(루트별로 모든 하위 포함))
+GET {{baseUrl}}/api/v1/categories/all?format=tree
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+
+}
+
+### 카테고리 조회(루트 + 즉시 하위(Depth=2까지만))
+GET {{baseUrl}}/api/v1/categories/all?format=tree&maxDepth=3
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+
+}

--- a/src/test/java/com/friday/commerce/http/category/category-name-update.http
+++ b/src/test/java/com/friday/commerce/http/category/category-name-update.http
@@ -1,0 +1,118 @@
+@baseUrl = http://localhost:10000
+
+### @name SignUp_Success
+# 정상 회원가입 시나리오
+POST {{baseUrl}}/api/v1/auth/sign-up
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456",
+  "username": "앨리스123",
+  "agreement": {
+    "termsOfService": true,
+    "privacy": true,
+    "marketing": true
+  },
+  "address": {
+    "zipCode": "06236",
+    "addressLine1": "서울시 강남구 테헤란로 123",
+    "addressLine2": "OO빌딩 5층",
+    "city": "서울",
+    "state": "강남구"
+  }
+}
+
+
+### 로그인 성공 시나리오
+POST http://localhost:10000/api/v1/auth/sign-in
+Content-Type: application/json
+Accept: application/json
+
+{
+  "email": "alice@example.com",
+  "password": "Aa!23456"
+}
+
+> {%
+  client.global.set("userId", response.body.userId.toFixed(0))
+  client.global.set("at", response.body.at)
+  client.global.set("rt", response.body.rt)
+%}
+
+
+### 카테고리 생성(startParentId, maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+  "path": "남자/상의/셔츠",
+  "delimiter": "/"
+}
+
+### 카테고리 생성(maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "셔츠/린넨",
+"delimiter": "/",
+"startParentId": 3665007757758464
+}
+
+### 카테고리 생성(다른 구분자, startParentId, maxDepthOverride: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "여자>아우터>자켓",
+"delimiter": ">",
+"startParentId": null,
+"maxDepthOverride": null
+}
+
+### 카테고리 생성(최대 요청 하드리밋. startParentId: null)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "스포츠/축구/유니폼/상의/반팔/나이키/24시즌",
+"delimiter": "/",
+"startParentId": null,
+"maxDepthOverride": 7
+}
+
+### 잘못된 카테고리 생성(빈 문자열 또는 delimiter만 있는 path)
+POST {{baseUrl}}/api/v1/categories
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+"path": "   ",
+"delimiter": "/",
+"startParentId": null,
+"maxDepthOverride": null
+}
+
+### 카테고리 조회(전체 트리(루트별로 모든 하위 포함))
+GET {{baseUrl}}/api/v1/categories/all?format=tree
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+
+}
+
+### 카테고리 조회(루트 + 즉시 하위(Depth=2까지만))
+GET {{baseUrl}}/api/v1/categories/all?format=tree&maxDepth=3
+Content-Type: application/json
+Authorization: Bearer {{at}}
+
+{
+
+}


### PR DESCRIPTION
하위 카테고리가 존재하면 삭제할 수 없습니다.
카테고리를 삭제하면 기록은 남기고, 동일한 카테고리 생성가능합니다.

# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.

카테고리 삭제를 구현했습니다.

- 하위 카테고리가 존재하는 경우에는 삭제할 수 없습니다.
- 카테고리 삭제 후, 동일한 카테고리명으로 생성할 수 있습니다. 즉, 이미 삭제된 카테고리와 새롭게 생성한 카테고리가 존재합니다.

## 🔍 관련 이슈
- Closes #70 

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카테고리 삭제 API(DELETE /api/v1/categories/{categoryId}) 추가. 소프트 삭제 적용 및 삭제 결과(카테고리 ID, 부모 ID, 경로, 깊이, 삭제 여부) 반환.
- Bug Fixes
  - 카테고리 생성 시 이미 소프트 삭제된 항목은 중복 검사에서 제외되어 동일 이름 재사용 가능.
  - 하위 활성 카테고리가 있으면 삭제 요청을 차단하고 적절한 오류 반환.
- Tests
  - 가입/로그인, 카테고리 생성·삭제, 트리 조회 등 HTTP 시나리오 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->