### PR TITLE
Monitoring: 그라파나, 프로메테우스 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 //    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.12.0'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-core'
 
 
     testCompileOnly 'org.projectlombok:lombok'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,8 +5,9 @@ networks:
     driver: bridge
 
 volumes:
-  mysql-data:
   redis-data:
+  prom-data:
+  grafana-data:
 
 services:
   redis:
@@ -39,5 +40,37 @@ services:
       # 아직 redis.conf 파일을 만들지 않았으니 일단 주석 유지
       # 만들었다면 위치는 ./docker/redis/redis.conf 로 맞추세요
       # - ./docker/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro
+    networks:
+      - friday-net
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: friday-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./docker/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prom-data:/prometheus
+    # 리눅스 도커에서 host.docker.internal 사용을 위해 host-gateway 매핑
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - friday-net
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: friday-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      TZ: Asia/Seoul
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
     networks:
       - friday-net

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'commerce-app'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      # EC2 호스트에서 실행 중인 스프링 부트 포트 (예: 10000)
+      # 아래 compose에서 host.docker.internal → host-gateway 로 매핑함
+      - targets: ['host.docker.internal:10000']
+        labels:
+          service: commerce

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -108,7 +108,7 @@ management:
     web:
       base-path: /actuator
       exposure:
-        include: health,info
+        include: health,info,prometheus
   endpoint:
     health:
       show-details: never


### PR DESCRIPTION
# 📦 Pull Request

### ✅ 작업 내용
> 해당하는 작업 항목을 선택해 주세요.
- [x] 기능 추가 또는 개선
- [ ] 버그 수정
- [ ] 문서 업데이트
- [ ] 리팩토링
- [ ] 테스트 추가

## 📋 변경 사항 요약
> 어떤 변경을 했는지 간단하게 설명해 주세요.



## 🔍 관련 이슈
- Closes #109 

## 💬 기타 의견
> 리뷰어가 알면 좋은 추가 정보가 있다면 작성

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 애플리케이션에 Prometheus 메트릭 노출을 추가하여 모니터링을 지원합니다 (/actuator/prometheus).
  * Docker Compose에 Prometheus(9090)와 Grafana(3000) 서비스를 추가해 메트릭 수집과 대시보드 시각화를 제공합니다.

* 잡무(Chores)
  * 프로덕션 설정에서 Prometheus 엔드포인트를 노출하도록 관리 엔드포인트 범위를 확장했습니다.
  * Prometheus/Grafana용 영구 볼륨을 추가하고 기본 네트워크에 연결했습니다.
  * Prometheus 설정 파일을 포함하고 기본 스크레이프 주기를 구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->